### PR TITLE
Add Kubernetes scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ All commands generate detailed `.log` files with full terminal output:
 | `scan-arm` | Azure ARM templates | ARM-TTK, Checkov |
 | `scan-bicep` | Azure Bicep templates | Bicep CLI, Checkov |
 | `scan-gcp` | GCP Deployment Manager | Checkov, GCloud validation |
+| `scan-kubernetes` | Kubernetes manifests | kube-score, Kubescape |
 
 ## Quick Start
 
@@ -143,6 +144,9 @@ docker run -it --rm -v "$(pwd):/work" spd109/devops-uat:latest scan-bicep templa
 
 # GCP templates
 docker run -it --rm -v "$(pwd):/work" spd109/devops-uat:latest scan-gcp template.yaml
+
+# Kubernetes manifests
+docker run -it --rm -v "$(pwd):/work" spd109/devops-uat:latest scan-kubernetes kubernetes/
 ```
 
 ### Cross-Platform Command Reference
@@ -585,6 +589,7 @@ docker run --rm -v "%cd%:/work" spd109/devops-uat:latest scan-cloudformation tes
 docker run --rm -v "%cd%:/work" spd109/devops-uat:latest scan-arm test-files/azure-arm/
 docker run --rm -v "%cd%:/work" spd109/devops-uat:latest scan-bicep test-files/azure-bicep/
 docker run --rm -v "%cd%:/work" spd109/devops-uat:latest scan-gcp test-files/gcp-deployment-manager/
+docker run --rm -v "%cd%:/work" spd109/devops-uat:latest scan-kubernetes test-files/kubernetes/
 docker run --rm spd109/devops-uat:latest scan-docker nginx:latest
 
 REM Test specific vulnerable files
@@ -600,6 +605,7 @@ docker run -it --rm -v "${PWD}:/work" spd109/devops-uat:latest scan-cloudformati
 docker run -it --rm -v "${PWD}:/work" spd109/devops-uat:latest scan-arm test-files/azure-arm/
 docker run -it --rm -v "${PWD}:/work" spd109/devops-uat:latest scan-bicep test-files/azure-bicep/
 docker run -it --rm -v "${PWD}:/work" spd109/devops-uat:latest scan-gcp test-files/gcp-deployment-manager/
+docker run -it --rm -v "${PWD}:/work" spd109/devops-uat:latest scan-kubernetes test-files/kubernetes/
 docker run -it --rm spd109/devops-uat:latest scan-docker nginx:latest
 ```
 
@@ -611,6 +617,7 @@ docker run -it --rm -v "$(pwd):/work" spd109/devops-uat:latest scan-cloudformati
 docker run -it --rm -v "$(pwd):/work" spd109/devops-uat:latest scan-arm test-files/azure-arm/
 docker run -it --rm -v "$(pwd):/work" spd109/devops-uat:latest scan-bicep test-files/azure-bicep/
 docker run -it --rm -v "$(pwd):/work" spd109/devops-uat:latest scan-gcp test-files/gcp-deployment-manager/
+docker run -it --rm -v "$(pwd):/work" spd109/devops-uat:latest scan-kubernetes test-files/kubernetes/
 docker run -it --rm spd109/devops-uat:latest scan-docker nginx:latest
 ```
 
@@ -658,6 +665,7 @@ Each test file should trigger multiple security findings:
 - `scanners/scan-arm.sh` - ARM-TTK + Checkov
 - `scanners/scan-bicep.sh` - Bicep CLI + Checkov
 - `scanners/scan-gcp.sh` - Checkov + GCloud validation
+- `scanners/scan-kubernetes.sh` - kube-score + Kubescape
 
 ## Troubleshooting
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -41,6 +41,7 @@ show_help() {
     echo "  scan-arm <file>               - Scan Azure ARM templates"
     echo "  scan-bicep <file>             - Scan Azure Bicep files"
     echo "  scan-gcp <file>               - Scan GCP Deployment Manager"
+    echo "  scan-kubernetes <path>        - Scan Kubernetes manifests"
     echo ""
     echo "UPDATE COMMANDS:"
     echo "  update-status                 - Show security update status"
@@ -50,6 +51,7 @@ show_help() {
     echo "EXAMPLES:"
     echo "  docker run -it --rm -v \"\$(pwd):/work\" spd109/devops-uat:latest scan-terraform terraform/"
     echo "  docker run -it --rm -v \"\$(pwd):/work\" spd109/devops-uat:latest scan-docker nginx:latest"
+    echo "  docker run -it --rm -v \"\$(pwd):/work\" spd109/devops-uat:latest scan-kubernetes kubernetes/"
     echo ""
     echo "📁 Current working directory contents:"
     ls -la /work 2>/dev/null || echo "   (No files found - volume mount required for file scanning)"
@@ -142,7 +144,7 @@ main() {
     
     # Check if it's a scanner command
     case "$COMMAND" in
-        scan-terraform|scan-cloudformation|scan-docker|scan-arm|scan-bicep|scan-gcp)
+        scan-terraform|scan-cloudformation|scan-docker|scan-arm|scan-bicep|scan-gcp|scan-kubernetes)
             TARGET="$1"
             
             # For Docker image scanning, don't require volume mount
@@ -179,6 +181,9 @@ main() {
                 scan-gcp)
                     exec /usr/local/bin/tools/scan-gcp.sh "$@"
                     ;;
+                scan-kubernetes)
+                    exec /usr/local/bin/tools/scan-kubernetes.sh "$@"
+                    ;;
             esac
             ;;
         *)
@@ -196,10 +201,10 @@ main() {
                 echo ""
                 echo "Available scanners:"
                 echo "  scan-terraform, scan-cloudformation, scan-docker, scan-arm (or scan-azure-arm),"
-                echo "  scan-bicep (or scan-azure-bicep), scan-gcp"
+                echo "  scan-bicep (or scan-azure-bicep), scan-gcp, scan-kubernetes"
                 echo ""
                 echo "Available tools:"
-                echo "  terraform, tflint, tfsec, checkov, trivy, cfn-lint, bicep"
+                echo "  terraform, tflint, tfsec, checkov, trivy, cfn-lint, bicep, kube-score, kubescape"
                 echo ""
                 show_help
                 exit 1

--- a/docker-tools-help.sh
+++ b/docker-tools-help.sh
@@ -39,6 +39,8 @@ Terraform Tools:
 Security Tools:
   - snyk-tool iac test <file>             # Snyk security scanner
   - detect-secrets scan <file>            # Secrets detection
+  - kube-score-tool <file>               # Kubernetes best-practice analysis
+  - kubescape-tool scan <path>           # Kubernetes security scanning
 
 Utility Commands:
   - update-tools                          # Updates all tools to latest versions

--- a/scanners/scan-kubernetes.sh
+++ b/scanners/scan-kubernetes.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Enhanced Kubernetes Scanner with Comprehensive Logging
+# Usage: scan-kubernetes <file_or_directory>
+
+set +e  # Handle errors gracefully
+
+cd /work
+
+TARGET="$1"
+TIMESTAMP=$(date '+%Y%m%d-%H%M%S')
+OUTPUT_PATH="/work/kubernetes-scan-report-${TIMESTAMP}.log"
+
+log_message() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$OUTPUT_PATH"
+}
+
+log_success() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ✅ SUCCESS: $1" | tee -a "$OUTPUT_PATH"
+}
+
+log_warning() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ⚠️  WARNING: $1" | tee -a "$OUTPUT_PATH"
+}
+
+log_error() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ❌ ERROR: $1" | tee -a "$OUTPUT_PATH"
+}
+
+log_section() {
+    echo "" | tee -a "$OUTPUT_PATH"
+    echo "============================================================" | tee -a "$OUTPUT_PATH"
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$OUTPUT_PATH"
+    echo "============================================================" | tee -a "$OUTPUT_PATH"
+}
+
+if [ -z "$TARGET" ]; then
+    echo "❌ Usage: scan-kubernetes <file_or_directory>"
+    echo "   Examples:"
+    echo "     scan-kubernetes deployment.yaml"
+    echo "     scan-kubernetes manifests/"
+    exit 1
+fi
+
+TARGET=$(echo "$TARGET" | sed 's|^/work/||')
+
+echo "=================================================================" > "$OUTPUT_PATH"
+echo "        KUBERNETES MANIFEST SECURITY SCAN REPORT" >> "$OUTPUT_PATH"
+echo "=================================================================" >> "$OUTPUT_PATH"
+echo "Target: $TARGET" >> "$OUTPUT_PATH"
+echo "Scan Started: $(date)" >> "$OUTPUT_PATH"
+echo "Scanners: kube-score + kubescape" >> "$OUTPUT_PATH"
+echo "=================================================================" >> "$OUTPUT_PATH"
+echo "" >> "$OUTPUT_PATH"
+
+log_section "KUBE-SCORE ANALYSIS"
+FILES="$TARGET"
+if [ -d "$TARGET" ]; then
+    FILES=$(find "$TARGET" -name '*.yaml' -o -name '*.yml' 2>/dev/null)
+fi
+
+if command -v kube-score >/dev/null 2>&1; then
+    log_message "Running kube-score analysis..."
+    kube-score score $FILES 2>&1 | tee -a "$OUTPUT_PATH"
+    KUBESCORE_EXIT=${PIPESTATUS[0]}
+    if [ $KUBESCORE_EXIT -eq 0 ]; then
+        log_success "kube-score analysis completed"
+    else
+        log_warning "kube-score completed with issues (exit code: $KUBESCORE_EXIT)"
+    fi
+else
+    log_error "kube-score not found in container"
+fi
+
+log_section "KUBESCAPE SECURITY SCAN"
+if command -v kubescape >/dev/null 2>&1; then
+    log_message "Running kubescape scan..."
+    kubescape scan "$TARGET" 2>&1 | tee -a "$OUTPUT_PATH"
+    KUBESCAPE_EXIT=${PIPESTATUS[0]}
+    if [ $KUBESCAPE_EXIT -eq 0 ]; then
+        log_success "kubescape scan completed"
+    else
+        log_warning "kubescape scan completed with issues (exit code: $KUBESCAPE_EXIT)"
+    fi
+else
+    log_error "kubescape not found in container"
+fi
+
+log_section "SCAN COMPLETE"
+log_message "Scan finished: $(date)"


### PR DESCRIPTION
## Summary
- add `scan-kubernetes.sh` for kube-score and kubescape checks
- install kube-score and kubescape in Dockerfile
- link new script and update entrypoint help and routing
- document Kubernetes scanning command and tools
- extend help script with kube-score and kubescape

## Testing
- `bash -n scanners/scan-kubernetes.sh`

------
https://chatgpt.com/codex/tasks/task_b_683a46c281c48331866f6bb736230ee1